### PR TITLE
Fix: preserve templated table rows and prevent malformed XML; error on missing keys

### DIFF
--- a/internal/docx/chart.go
+++ b/internal/docx/chart.go
@@ -32,9 +32,10 @@ func ApplyTemplateToXml(f *zip.File, templateValues any, templateFuncs template.
 		return nil, fmt.Errorf("unable to read chart file '%s': %w", f.Name, err)
 	}
 
-	tmpl, err := template.New(f.Name).
-		Funcs(templateFuncs).
-		Parse(PatchXml(string(fileContent)))
+    tmpl, err := template.New(f.Name).
+        Option("missingkey=error").
+        Funcs(templateFuncs).
+        Parse(PatchXml(string(fileContent)))
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse template: %w", err)
 	}

--- a/internal/docx/document.go
+++ b/internal/docx/document.go
@@ -155,9 +155,10 @@ func (d *documentMeta) ApplyTemplate(f *zip.File, zipWriter *zip.Writer, data an
 
 	documentXml = []byte(PatchXml(string(documentXml)))
 
-	tmpl, err := template.New(f.Name).
-		Funcs(d.templateFuncs).
-		Parse(string(documentXml))
+    tmpl, err := template.New(f.Name).
+        Option("missingkey=error").
+        Funcs(d.templateFuncs).
+        Parse(string(documentXml))
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse template in file '%s': %w", f.Name, err)
 	}
@@ -183,7 +184,9 @@ func (d *documentMeta) ApplyTemplate(f *zip.File, zipWriter *zip.Writer, data an
 
 	output = d.replaceTableCellBgColors(output)
 
-	output = removeEmptyTableRows(output)
+    output = flattenNestedTextRuns(output)
+
+    output = removeEmptyTableRows(output)
 
 	err = goziputils.RewriteFileIntoZipWriter(zipWriter, f, []byte(output))
 	if err != nil {

--- a/internal/docx/processing.go
+++ b/internal/docx/processing.go
@@ -9,16 +9,56 @@ import (
 
 // removeEmptyTableRows removes empty table rows from the provided XML string.
 func removeEmptyTableRows(srcXML string) string {
-	re := regexp.MustCompile(`<w:tr\b[^>]*>[\s\S]*?</w:tr>`)
-	matches := re.FindAllString(srcXML, -1)
-	for _, match := range matches {
-		if !strings.Contains(match, "<w:t></w:t>") {
-			continue
-		}
-		srcXML = strings.ReplaceAll(srcXML, match, "")
-	}
+    // A row should be considered "empty" only if it has:
+    // - no non‑whitespace text inside any <w:t>...</w:t>
+    // - and no visual content (drawings/shapes/alternate content blocks)
+    // Word frequently emits empty <w:t></w:t> runs as layout artifacts; removing
+    // any row that merely contains one of those is too aggressive and drops
+    // legitimate rows. This refined check keeps rows that visibly render.
 
-	return srcXML
+    trRe := regexp.MustCompile(`(?s)<w:tr\b[^>]*>.*?</w:tr>`) // match a table row
+    tRe := regexp.MustCompile(`(?is)<w:t[^>]*>(.*?)</w:t>`)     // capture text content
+    visRe := regexp.MustCompile(`(?is)<w:drawing\b|<w:pict\b|<mc:AlternateContent\b|<v:shape\b|<wps:spPr\b`)
+
+    isRowEmpty := func(row string) bool {
+        if visRe.MatchString(row) {
+            return false
+        }
+
+        texts := tRe.FindAllStringSubmatch(row, -1)
+        if len(texts) == 0 {
+            // No text nodes and no visual content => treat as empty
+            return true
+        }
+
+        for _, m := range texts {
+            if strings.TrimSpace(m[1]) != "" { // any visible char keeps the row
+                return false
+            }
+        }
+        return true
+    }
+
+    return trRe.ReplaceAllStringFunc(srcXML, func(row string) string {
+        if isRowEmpty(row) {
+            return ""
+        }
+        return row
+    })
+}
+
+// flattenNestedTextRuns fixes cases where a template function that returns
+// `<w:rPr>..</w:rPr><w:t>..</w:t>` got injected inside an existing `<w:t>`.
+// That produces invalid nesting like:
+//   <w:t> <w:rPr>..</w:rPr><w:t>text</w:t> </w:t>
+// Replace it with:
+//   <w:rPr>..</w:rPr><w:t>text</w:t>
+func flattenNestedTextRuns(srcXML string) string {
+    nestedRe := regexp.MustCompile(`(?is)<w:t[^>]*>\s*(<w:rPr>[\s\S]*?</w:rPr>)\s*<w:t[^>]*>([\s\S]*?)</w:t>\s*</w:t>`) // greedy across whitespace
+    for nestedRe.MatchString(srcXML) {
+        srcXML = nestedRe.ReplaceAllString(srcXML, `${1}<w:t>${2}</w:t>`)
+    }
+    return srcXML
 }
 
 // guardSpaces wraps the input text in

--- a/internal/xlsx/xlsx.go
+++ b/internal/xlsx/xlsx.go
@@ -11,11 +11,12 @@ import (
 
 // ApplyTemplateToCells applies the templateValues to the given file content and returns the modified content.
 func ApplyTemplateToCells(f *zip.File, templateValues any, fileContent []byte) ([]byte, error) {
-	tmpl, err := template.New(f.Name).
-		Funcs(template.FuncMap{
-			"toNumberCell": ToNumberCell,
-		}).
-		Parse(docx.PatchXml(string(fileContent)))
+    tmpl, err := template.New(f.Name).
+        Option("missingkey=error").
+        Funcs(template.FuncMap{
+            "toNumberCell": ToNumberCell,
+        }).
+        Parse(docx.PatchXml(string(fileContent)))
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse template: %w", err)
 	}


### PR DESCRIPTION
This PR fixes two related issues observed when templating DOCX tables:

1) Legitimate rows were removed because `removeEmptyTableRows` treated the presence of `<w:t></w:t>` as a signal to delete a row. Word often inserts empty runs around template tokens, so valid rows disappeared.

2) The generated `document.xml` became malformed in cells using styling helpers because styled text XML (`<w:rPr>…</w:rPr><w:t>…</w:t>`) could get injected inside an existing `<w:t>`, producing illegal nested `<w:t>` tags. Additionally, missing keys in templates (e.g., using `.Target` instead of iterating `.Targets`) yielded the literal `<no value>` inside `<w:t>`, corrupting XML.

Changes:
- Refine row cleanup to drop only rows with no non‑whitespace text and no visual content.
- Add a normalization pass that flattens nested `<w:t>` around styled runs.
- Set `template.Option("missingkey=error")` across document, chart, and xlsx templating to fail fast on missing keys.

Result:
- Templated rows (e.g., with `{{tableCellBgColor .CVSSv31.Severity.Color}}` and `{{styledText .CVSSv31.Severity.Label (list "b" "#FFFFFF")}}`) are preserved.
- `document.xml` remains well‑formed.
- Misbound data causes clear template errors instead of embedding `<no value>`.

Note:
- Templates should reference existing fields; for lists, iterate (e.g., `{{range .Targets}}…{{end}}`) rather than using a singular `.Target`.

(Generated by AI)